### PR TITLE
Improve ClusterCovariance and methods for GroupedArray

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,3 +13,9 @@ Combinatorics = "1"
 StatsBase = "0.32, 0.33"
 Tables = "1"
 julia = "1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/src/Vcov.jl
+++ b/src/Vcov.jl
@@ -5,6 +5,8 @@ using LinearAlgebra
 using StatsBase
 using Tables
 
+import Base: @propagate_inbounds, size, length, getindex, show
+
 ##############################################################################
 ##
 ## Mimimum RegressionModel used in Vcov

--- a/src/covarianceestimators/vcovrobust.jl
+++ b/src/covarianceestimators/vcovrobust.jl
@@ -1,6 +1,14 @@
 struct RobustCovariance <: CovarianceEstimator end
 
+"""
+    robust()
+
+Estimate variance-covariance matrix with a heteroskedasticity-robust estimator.
+"""
 robust() = RobustCovariance()
+
+show(io::IO, ::RobustCovariance) =
+    print(io, "Heteroskedasticity-robust covariance estimator")
 
 function S_hat(x::RegressionModel, ::RobustCovariance)
     m = modelmatrix(x)

--- a/src/covarianceestimators/vcovsimple.jl
+++ b/src/covarianceestimators/vcovsimple.jl
@@ -1,6 +1,14 @@
 struct SimpleCovariance <: CovarianceEstimator end
 
+"""
+    simple()
+
+Estimate variance-covariance matrix with a simple estimator.
+"""
 simple() = SimpleCovariance()
+
+show(io::IO, ::SimpleCovariance) =
+    print(io, "Simple covariance estimator")
 
 function S_hat(x::RegressionModel, ::SimpleCovariance)
 	rmul!(crossmodelmatrix(x), sum(abs2, residuals(x)))

--- a/test/GroupedArray.jl
+++ b/test/GroupedArray.jl
@@ -1,0 +1,18 @@
+@testset "GroupedArray" begin
+    N = 10
+    a1 = collect(1:N)
+    g1 = group(a1)
+    @test g1 == GroupedArray(collect(UInt32, 1:N), N)
+    @test size(g1) == (N,)
+    @test length(g1) == N
+    @test g1[1] == UInt32(1)
+    @test g1[1:2] == [UInt32(1), UInt32(2)]
+    @test g1[g1.<=2] == g1[[1,2]] == g1[1:2]
+
+    a2 = [1,2]
+    @test_throws DimensionMismatch group(a1, a2)
+
+    a = rand(N)
+    g = group(a)
+    @test factorize!(g) == g
+end

--- a/test/estimators.jl
+++ b/test/estimators.jl
@@ -1,0 +1,34 @@
+@testset "SimpleCovariance" begin
+    v = simple()
+    @test sprint(show, v) == "Simple covariance estimator"
+end
+
+@testset "RobustCovariance" begin
+    v = robust()
+    @test sprint(show, v) == "Heteroskedasticity-robust covariance estimator"
+end
+
+@testset "ClusterCovariance" begin
+    @test_throws MethodError cluster()
+    c1 = cluster(:a)
+    @test names(c1) == (:a,)
+    @test length(c1) == 1
+    c2 = cluster(:a, :b)
+    @test names(c2) == (:a, :b)
+    @test length(c2) == 2
+
+    @test sprint(show, c1) == "Cluster-robust covariance estimator"
+    @test sprint(show, MIME("text/plain"), c1) == """
+        1-way cluster-robust covariance estimator:
+          a"""
+    @test sprint(show, MIME("text/plain"), c2) == """
+        2-way cluster-robust covariance estimator:
+          a
+          b"""
+
+    N = 10
+    a1 = collect(1:N)
+    g1 = group(a1)
+    c1 = cluster((:a,), (g1,))
+    @test nclusters(c1) == (a=N,)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,19 @@
+using Test
+using Vcov: GroupedArray, group, factorize!,
+    simple, robust, cluster, names, nclusters
+
+import Base: ==
+
+const tests = [
+    "GroupedArray",
+    "estimators"
+]
+
+==(x::GroupedArray{N}, y::GroupedArray{N}) where N = x.refs == y.refs && x.n == y.n
+
+printstyled("Running tests:\n", color=:blue, bold=true)
+
+for test in tests
+    include("$test.jl")
+    println("\033[1m\033[32mPASSED\033[0m: $(test)")
+end


### PR DESCRIPTION
I have made the following three changes:

1. Change how `ClusterCovariance` is defined to add more restrictions on the fields. The one in v0.4.0 does not impose any restriction.
2. Define methods of `show` for type pretty-printing.
3. Make the same changes to `GroupedArray` as in https://github.com/FixedEffects/FixedEffects.jl/pull/43.
4. Add some docstrings to methods that are more likely to be exposed to end-users.

One thing to be noted is that now `cluster(names::Symbol...)` will only work if at least one name is provided. The original one won't generate error when calling `cluster()`. But, there will be an error when doing the estimation.
