### PR TITLE
Improve completecases for ClusterCovariance

### DIFF
--- a/src/covarianceestimators/vcovcluster.jl
+++ b/src/covarianceestimators/vcovcluster.jl
@@ -152,10 +152,17 @@ end
 
 function Vcov.completecases(table, v::ClusterCovariance)
     Tables.istable(table) || throw(ArgumentError("completecases requires a table input"))
-    out = trues(length(Tables.rows(table)))
+    N = length(Tables.rows(table))
+    out = trues(N)
+    aux = BitVector(undef, N)
     columns = Tables.columns(table)
     for name in names(v)
-        out .&= .!ismissing.(Tables.getcolumn(columns, name))
+        col = Tables.getcolumn(columns, name)
+        if Missing <: eltype(col)
+            # The use of aux follows DataFrames.completecases for performance reasons
+            aux .= .!ismissing.(col)
+            out .&= aux
+        end
     end
     return out
 end

--- a/src/covarianceestimators/vcovcluster.jl
+++ b/src/covarianceestimators/vcovcluster.jl
@@ -160,6 +160,7 @@ function Vcov.completecases(table, v::ClusterCovariance)
         col = Tables.getcolumn(columns, name)
         if Missing <: eltype(col)
             # The use of aux follows DataFrames.completecases for performance reasons
+            # See https://github.com/JuliaData/DataFrames.jl/pull/2726
             aux .= .!ismissing.(col)
             out .&= aux
         end

--- a/test/estimators.jl
+++ b/test/estimators.jl
@@ -28,7 +28,20 @@ end
 
     N = 10
     a1 = collect(1:N)
+    a2 = convert(Vector{Union{Float64, Missing}}, a1)
+    a2[1] = missing
+    cols = (a=a1, b=a2)
+
     g1 = group(a1)
     c1 = cluster((:a,), (g1,))
     @test nclusters(c1) == (a=N,)
+    c1m = materialize(cols, cluster(:a))
+    @test c1m.clusternames == c1.clusternames
+    @test c1m.clusters[1] == g1 
+
+    @test completecases(cols, c1) == trues(N)
+    c2 = materialize(cols, cluster(:b))
+    @test completecases(cols, c2) == (1:N.!=1)
+    c3 = materialize(cols, cluster(:a, :b))
+    @test completecases(cols, c3) == (1:N.!=1)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using Test
 using Vcov: GroupedArray, group, factorize!,
-    simple, robust, cluster, names, nclusters
+    completecases, materialize, simple, robust, cluster, names, nclusters
 
 import Base: ==
 


### PR DESCRIPTION
I have made some changes to `completecases` that echos the recent changes made with `DataFrames.completecases`.
Now, finding missing values will only happen when the element type of the column contains `Missing`.